### PR TITLE
Tran step and maxstep

### DIFF
--- a/spice/spice_simcmd.py
+++ b/spice/spice_simcmd.py
@@ -145,6 +145,10 @@ class spice_simcmd(thesdk):
         Random seed for the Monte Carlo instance. Default None (random seed).
     model_info : bool
         For Spectre only! If true, print model parameters to raw-file.
+    maxstep : float
+        Maximum time step Spectre simulator will use during transient analysis
+    step: float
+        According to Spectre: minimum time step used by the simulator solely to maintain the aesthetics of the computed waveforms.
 
     Examples
     --------
@@ -184,6 +188,8 @@ class spice_simcmd(thesdk):
             self.mc = kwargs.get('mc',False)
             self.mc_seed = kwargs.get('mc_seed',None)
             self.model_info = kwargs.get('model_info', False)
+            self.step = kwargs.get('step', None)
+            self.maxstep = kwargs.get('maxstep', None)
             # Make list, if they are not already
             self.sweep = kwargs.get('sweep',[]) if type(kwargs.get('sweep', [])) == list else [kwargs.get('sweep')]
             self.subcktname = kwargs.get('subcktname',[]) if type(kwargs.get('subcktname', [])) == list else [kwargs.get('subcktname')]

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -530,6 +530,10 @@ class testbench(spice_module):
                             self._simcmdstr += 'method=%s ' %  (str(val.method))
                         if val.cmin is not None:
                             self._simcmdstr += 'cmin=%s ' %  (str(val.cmin))
+                        if val.maxstep is not None:
+                            self._simcmdstr += 'maxstep=%s ' % (str(val.maxstep))
+                        if val.step is not None:
+                            self._simcmdstr += 'step=%s ' % (str(val.step))
                         self._simcmdstr += '\n\n' 
                     elif self.parent.model=='ngspice':
                         self._simcmdstr += '.%s %s %s %s\n' % \


### PR DESCRIPTION
Added functionality for controlling the step and maxstep parameters for Spectre transient analysis. Closes #41.

@dc14830 could you test whether this works for you? It ran fine on my side.

(ping @mkosunen)

