### PR TITLE
Consistent time stamped spectre simulation output

### DIFF
--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -805,20 +805,16 @@ class spice(thesdk,metaclass=abc.ABCMeta):
                                     rounder=int(str(strobeperiod)[-2:])+1
                                     idx=np.where(np.in1d(np.round(tvals,rounder),
                                         np.round(strobetimestamps,rounder)))
-                                    
                                     new_array=self.iofile_eventdict[val.ionames[0].upper()][idx]
-
+                                    _,idx=np.unique(np.round(new_array[:,0],rounder-1),return_index=True)
+                                    new_array=new_array[idx]
                                     # For initial debug
                                     if len(strobetimestamps)!=len(new_array):
                                         self.print_log(type='W',
                                                 msg='Oh no, something went wrong while reading the strobeperiod data')
                                         self.print_log(type='W',
                                                 msg='Check data lenghts!')
-                                        pdb.set_trace()
-                                        self.print_log(type='E',
-                                                msg='The length of strobeperiod data is incorrect.')
-
-                                    self.iofile_bundle.Members[name].Data= new_array
+                                    self.iofile_bundle.Members[name].Data=new_array
                                 else:
                                     self.iofile_bundle.Members[name].Data=self.iofile_eventdict[val.ionames[0].upper()]
                             else:

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -794,17 +794,31 @@ class spice(thesdk,metaclass=abc.ABCMeta):
                             # remove this.
                             if self.model == 'spectre':
                                 if 'strobeperiod' in self.tb.simcmdstr:
-                                    maxtime = np.max(self.iofile_eventdict[val.ionames[0].upper()][:,0])
-                                    mintime = np.min(self.iofile_eventdict[val.ionames[0].upper()][:,0])
+                                    tvals=self.iofile_eventdict[val.ionames[0].upper()][:,0]
+                                    maxtime = np.max(tvals)
+                                    mintime = np.min(tvals)
                                     for simulationcommand, simulationoption in self.simcmd_bundle.Members.items():
                                         strobeperiod = simulationoption.strobeperiod
                                     strobetimestamps = np.arange(mintime,maxtime,strobeperiod)
                                     # get the number of decimals for rounding to fix bug of
                                     # missing points
-                                    rounder=int(str(strobeperiod)[-2:])
-                                    idx=np.where(np.in1d(self.iofile_eventdict[val.ionames[0].upper()][:,0],
+                                    rounder=int(str(strobeperiod)[-2:])+1
+                                    idx=np.where(np.in1d(np.round(tvals,rounder),
                                         np.round(strobetimestamps,rounder)))
-                                    self.iofile_bundle.Members[name].Data=self.iofile_eventdict[val.ionames[0].upper()][idx]
+                                    
+                                    new_array=self.iofile_eventdict[val.ionames[0].upper()][idx]
+
+                                    # For initial debug
+                                    if len(strobetimestamps)!=len(new_array):
+                                        self.print_log(type='W',
+                                                msg='Oh no, something went wrong while reading the strobeperiod data')
+                                        self.print_log(type='W',
+                                                msg='Check data lenghts!')
+                                        pdb.set_trace()
+                                        self.print_log(type='E',
+                                                msg='The length of strobeperiod data is incorrect.')
+
+                                    self.iofile_bundle.Members[name].Data= new_array
                                 else:
                                     self.iofile_bundle.Members[name].Data=self.iofile_eventdict[val.ionames[0].upper()]
                             else:

--- a/spice/spice_simcmd.py
+++ b/spice/spice_simcmd.py
@@ -190,6 +190,7 @@ class spice_simcmd(thesdk):
             self.model_info = kwargs.get('model_info', False)
             self.step = kwargs.get('step', None)
             self.maxstep = kwargs.get('maxstep', None)
+            self.strobeperiod = kwargs.get('strobeperiod', None)
             # Make list, if they are not already
             self.sweep = kwargs.get('sweep',[]) if type(kwargs.get('sweep', [])) == list else [kwargs.get('sweep')]
             self.subcktname = kwargs.get('subcktname',[]) if type(kwargs.get('subcktname', [])) == list else [kwargs.get('subcktname')]

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -544,7 +544,7 @@ class testbench(spice_module):
                         if val.step is not None:
                             self._simcmdstr += 'step=%s ' % (str(val.step))
                         if val.strobeperiod is not None:
-                            self._simcmdstr += 'strobeperiod=%s ' % (str(val.strobeperiod))
+                            self._simcmdstr += 'strobeperiod=%s strobeoutput=strobeonly ' % (str(val.strobeperiod))
                         self._simcmdstr += '\n\n' 
                     elif self.parent.model=='ngspice':
                         self._simcmdstr += '.%s %s %s %s\n' % \

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -543,6 +543,8 @@ class testbench(spice_module):
                             self._simcmdstr += 'maxstep=%s ' % (str(val.maxstep))
                         if val.step is not None:
                             self._simcmdstr += 'step=%s ' % (str(val.step))
+                        if val.strobeperiod is not None:
+                            self._simcmdstr += 'strobeperiod=%s ' % (str(val.strobeperiod))
                         self._simcmdstr += '\n\n' 
                     elif self.parent.model=='ngspice':
                         self._simcmdstr += '.%s %s %s %s\n' % \


### PR DESCRIPTION
Solution for running spectre simulations with consistent time stamps. 
Example of usage: `_=spice_simcmd(self,sim='tran',strobeperiod=self.strobeperiod)`, so the strobeperiod is given as a parameter when calling spice_simcmd.

The reason for additions of filtering the values with corresponding period is that even with the option 
`strobeoption=strobeonly`
the output includes random points that have inconsistent time differences between them. Upon running many tests, this solution seems to work, and runs relatively quickly. 

The tests were run with strobeperiod values
`1e-13,1e-12,1.1e-12,1.56e-12,2e-12,3e-12,4e-12,5e-12,6e-12,7e-12,8e-12,9e-12,9.87e-12,1e-10,1e-11,6.66e-10` and the length of the vector was correct with all values but `9.87e-12`.

The advantage of this implementation when compared to running with sampling clock is that the simulation file reading time is significantly shorter, resulting in much faster simulation result procesisng.

Any comments @mkosunen @sporrasm ?