### PR TITLE
Fix a bug where the plotprogram can't be set from testbench

### DIFF
--- a/spice/spectre/spectre.py
+++ b/spice/spectre/spectre.py
@@ -28,7 +28,6 @@ class spectre(spice_common):
     """
 
     def __init__(self, parent=None,**kwargs):
-
             if parent==None:
                 self.print_log(type='F', msg="Parent of simulator module not given")
             else:
@@ -181,7 +180,12 @@ class spectre(spice_common):
         Options are ezwave (default) or viva.
         """
         if not hasattr(self, '_plotprogram'):
-            self._plotprogram='ezwave'
+            if hasattr(self.parent,'plotprogram'):
+                self._plotprogram=self.parent.plotprogram
+                # update plotprogcmd (have to call the property)
+                update=self.plotprogcmd
+            else:
+                self._plotprogram='ezwave' 
         return self._plotprogram
     @plotprogram.setter
     def plotprogram(self, value):

--- a/spice/spectre/spectre.py
+++ b/spice/spectre/spectre.py
@@ -199,15 +199,14 @@ class spectre(spice_common):
     def plotprogcmd(self):
         """ str : Command to be run for interactive simulations.
         """
-        if not hasattr(self, '_plotprogcmd'):
-            if self.plotprogram == 'ezwave':
-                self._plotprogcmd='%s -MAXWND -LOGfile %s/ezwave.log %s &' % \
-                        (self.plotprogram,self.parent.spicesimpath,self.parent.spicedbpath)
-            elif self.plotprogram == 'viva':
-                self._plotprogcmd='%s -datadir %s -nocdsinit &' % \
-                        (self.plotprogram,self.parent.spicedbpath)
-            else:
-                self.print_log(type='F',msg='Unsupported plot program \'%s\'.' % self.plotprogram)
+        if self.plotprogram == 'ezwave':
+            self._plotprogcmd='%s -MAXWND -LOGfile %s/ezwave.log %s &' % \
+                    (self.plotprogram,self.parent.spicesimpath,self.parent.spicedbpath)
+        elif self.plotprogram == 'viva':
+            self._plotprogcmd='%s -datadir %s -nocdsinit &' % \
+                    (self.plotprogram,self.parent.spicedbpath)
+        else:
+            self.print_log(type='F',msg='Unsupported plot program \'%s\'.' % self.plotprogram)
         return self._plotprogcmd
     @plotprogcmd.setter
     def plotprogcmd(self, value):


### PR DESCRIPTION
In it's current state the plotprogram can't be set from the testbench (at least not by just calling e.g. self.plotprogram='viva'), as the value does not propagate to the spectre specific class. This implementation at least would fix the issue, however I am not sure if this is the way we want to propagate values from parent.

ping @mkosunen @sporrasm 