### PR TITLE
Remove file changes for parallel runs

### DIFF
--- a/spice/spectre/spectre_testbench.py
+++ b/spice/spectre/spectre_testbench.py
@@ -463,12 +463,21 @@ class spectre_testbench(testbench_common):
         '''
         if not hasattr(self, '_num_cols'):
             self._num_cols=0
+            # If power is extracted, it adds current line
+            for name, val in self.dcsources.Members.items():
+                if val.extract: 
+                    self._num_cols += 1
             for name, val in self.iofiles.Members.items():
                 if val.dir.lower() == 'out':
-                    if val.datatype.lower() == 'complex':
-                        self._num_cols += 2
+                    if '<' and '>' in name:
+                        start=name.split('<')[1]
+                        start=start.split(':')
+                        higher=start[0]
+                        lower=start[1].split('>')[0]
+                        add=int(higher)-int(lower)
+                        self._num_cols += 2*add if val.datatype.lower()=='complex' else add
                     else:
-                        self._num_cols += 1
+                        self._num_cols += 2 if val.datatype.lower()=='complex' else 1
         self._num_cols *= 15
         return self._num_cols
 

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -172,11 +172,16 @@ class testbench(testbench_common):
                                     # Break looping once found
                                     break
                             if found:
-                                # Match is case insensitive, we will rename for perfect match.
-                                self.print_log(type='I',msg='Renaming DSPF top cell name accordingly from "%s" to "%s".' % (cellname,self.parent.name))
-                                with fileinput.FileInput(dspfpath,inplace=True,backup='.bak') as f:
-                                    for line in f:
-                                        print(line.replace(self._origcellname,self.parent.name),end='')
+                                if not self.parent.par: # The line replacing does not work with parallel simulations (crashes)
+                                    # Match is case insensitive, we will rename for perfect match.
+                                    self.print_log(type='I',msg='Renaming DSPF top cell name accordingly from "%s" to "%s".' % (cellname,self.parent.name))
+                                    with fileinput.FileInput(dspfpath,inplace=True,backup='.bak') as f:
+                                        for line in f:
+                                            print(line.replace(self._origcellname,self.parent.name),end='')
+                                else: #Parallel run
+                                    self.print_log(type='I',
+                                            msg='Parallel run detected. Not renaming DSPF top cell name, assuming "%s" is the same as "%s"' % (cellname,self.parent.name))
+                                    
                             else:
                                 self.print_log(type='F',msg='No DESIGN string in DSPF matching %s or %s. Aborting' %(self.parent.name. self.dut.custom_subckt_name))
 


### PR DESCRIPTION
If the fileinput origcellname and parent.name are changed in parallel run, it crashes as multiple runs try to do the change in the file at the same time. 

This fix adds a check that if a parallel run is present it does not perform this change, and it seems to fix the issue

(Ping @mkosunen @sporrasm )