### PR TITLE
V1.11 dev

### DIFF
--- a/spice/spectre/spectre_testbench.py
+++ b/spice/spectre/spectre_testbench.py
@@ -463,12 +463,21 @@ class spectre_testbench(testbench_common):
         '''
         if not hasattr(self, '_num_cols'):
             self._num_cols=0
+            # If power is extracted, it adds current line
+            for name, val in self.dcsources.Members.items():
+                if val.extract: 
+                    self._num_cols += 1
             for name, val in self.iofiles.Members.items():
                 if val.dir.lower() == 'out':
-                    if val.datatype.lower() == 'complex':
-                        self._num_cols += 2
+                    if '<' and '>' in name:
+                        start=name.split('<')[1]
+                        start=start.split(':')
+                        higher=start[0]
+                        lower=start[1].split('>')[0]
+                        add=int(higher)-int(lower)
+                        self._num_cols += 2*add if val.datatype.lower()=='complex' else add
                     else:
-                        self._num_cols += 1
+                        self._num_cols += 2 if val.datatype.lower()=='complex' else 1
         self._num_cols *= 15
         return self._num_cols
 

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -165,7 +165,7 @@ class testbench(testbench_common):
                                         self.print_log(type='I',msg='Found DSPF cell name matching to original top-level cell name.')
                                         found = True
                                         self._origcellname=cellname
-                                    elif cellname.lower() == self.dut.custom_subckt_name:
+                                    elif cellname.lower() == self.dut.custom_subckt_name.lower():
                                         self.print_log(type='I',msg='Found DSPF cellname matching to custom_subckt_name: %s.' % cellname)
                                         found = True
                                         self._origcellname=cellname

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -137,6 +137,17 @@ class testbench(testbench_common):
     def includecmd(self,value):
         self._includecmd=None
 
+    def copy_dspf(self):
+        try:
+            for cell in self.parent.dspf:
+                src = os.path.join(self.parent.spicesrcpath, '%s.pex.dspf' % cell)
+                dest = os.path.join(self.parent.spicesimpath, '%s.pex.dspf' % cell)
+                shutil.copy(src, dest)
+        except:
+            self.print_log(type='F',msg='Could not copy DSPF for cell %s to %s' %(cell, dest))
+            self.print_log(type='F',msg=traceback.format_exc())
+
+
     # DSPF include commands
     @property
     def dspfincludecmd(self):
@@ -147,11 +158,12 @@ class testbench(testbench_common):
         """
         if not hasattr(self,'_dspfincludecmd'):
             if len(self.parent.dspf) > 0:
+                self.copy_dspf()
                 self.print_log(type='I',msg='Including exctracted parasitics from DSPF.')
                 self._dspfincludecmd = "%s Extracted parasitics\n"  % self.parent.spice_simulator.commentchar
                 origcellmatch = re.compile(r"DESIGN")
                 for cellname in self.parent.dspf:
-                    dspfpath = '%s/%s.pex.dspf' % (self.parent.spicesrcpath,cellname)
+                    dspfpath = '%s/%s.pex.dspf' % (self.parent.spicesimpath,cellname)
                     try:    
                         found = False
                         with open(dspfpath) as dspffile:

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -178,12 +178,12 @@ class testbench(testbench_common):
                                     for line in f:
                                         print(line.replace(self._origcellname,self.parent.name),end='')
                             else:
-                                self.print_log(type='F',msg='No DESIGN string in DSPF matching %s or %s. Aborting' %(self.parent.name. self.dut.custom_subckt_name))
+                                self.print_log(type='F',msg='No DESIGN string in DSPF matching %s or %s. Aborting' %(self.parent.name, self.dut.custom_subckt_name))
 
                             self.print_log(type='I',msg='Including DSPF-file: %s' % dspfpath)
                             self._dspfincludecmd += "%s \"%s\"\n" % (self.parent.spice_simulator.dspfinclude,dspfpath)
                     except:
-                        self.print_log(type='F',msg='No DESIGN string in DSPF matching %s or %s. Aborting' %(self.parent.name. self.dut.custom_subckt_name))
+                        self.print_log(type='F',msg='No DESIGN string in DSPF matching %s or %s. Aborting' %(self.parent.name, self.dut.custom_subckt_name))
                         self.print_log(type='F',msg=traceback.format_exc())
             else:
                 self._dspfincludecmd = ''

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -11,6 +11,7 @@ import sys
 import subprocess
 import shlex
 import fileinput
+import shutil
 from thesdk import *
 from spice.testbench_common import testbench_common
 from spice.ngspice.ngspice_testbench import ngspice_testbench


### PR DESCRIPTION
This PR fixes some bugs in dspf renaming. In addition, this also fixes parallel threads crashing when renaming dspf top-cell, provided that all parallel threads were using the same dspf file.

The proposed solution by @mkosunen to copy the dspf to the spicesimpath was utilized.

This PR, should it be merged, closes PR #75. The branch of that PR may be deleted. I cherry picked commit 7e34ac2e5a270c9dac4d0f42ad2eef26a3ed20cf from that branch to this one.

@vlahtin could you try it out and see if it fixes the issue?