### PR TITLE
Enable steady state and S-parameter analyses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "psf_utils"]
+	path = psf_utils
+	url = git@github.com:KenKundert/psf_utils.git

--- a/init_submodules.sh
+++ b/init_submodules.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#Selective initialization of submodules
+#Written by by Marko Kosunen, marko.kosunen@aalto.fi, 2017
+DIR=$( cd `dirname $0` && pwd )
+SUBMODULES="\
+    ./psf_utils/ \
+"
+
+git submodule sync
+for mod in $SUBMODULES; do 
+    git submodule update --init $mod
+    cd ${mod}
+    if [ -f ./init_submodules.sh ]; then
+        ./init_submodules.sh
+    fi
+    cd ${DIR}
+
+done
+exit 0
+
+

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -835,6 +835,14 @@ class spice(spice_common):
                             except KeyError:
                                 self.print_log(type='E', msg='Invalid ioname %s for iofile %s' % (key, name))
                         self.iofile_bundle.Members[name].Data=data
+                elif val.iotype=='psfascii':
+                    if first:
+                        self.iofile_bundle.Members[name].read() #read() should use psf_utils
+                        first=False
+                    try:
+                        self.iofile_bundle.Members[name].Data=self.iofile_eventdict[val.ionames[0].upper()]
+                    except KeyError:
+                        self.print_log(type='E',msg='Invalid ioname %s for iofile %s' % (val.ionames[0], name))
                 else:
                     self.iofile_bundle.Members[name].read()
             elif val.dir.lower()=='output':

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -97,10 +97,12 @@ class spice(spice_common):
         if not hasattr(self,'_spice_simulator'):
             if self.model == 'ngspice':
                 self._spice_simulator=ngspice(parent=self)
-            if self.model == 'eldo':
+            elif self.model == 'eldo':
                 self._spice_simulator=eldo(parent=self)
-            if self.model == 'spectre':
+            elif self.model == 'spectre':
                 self._spice_simulator=spectre(parent=self)
+            else:
+                self.print_log(type='F', msg=f'Unsupported simulator: {self.model}')
         return self._spice_simulator
    
 

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -53,6 +53,7 @@ from spice.spice_simcmd import spice_simcmd as spice_simcmd
 from spice.spice_iofile import spice_iofile as spice_iofile
 from spice.spice_dcsource import spice_dcsource as spice_dcsource
 from spice.spice_module import spice_module as spice_module
+from spice.spice_port import spice_port
 # Simulator modules
 from spice.ngspice.ngspice import ngspice
 from spice.eldo.eldo import eldo

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -951,6 +951,20 @@ class spice(spice_common):
     def spice_tb(self, value):
             self._spice_tb = value
 
+    @property
+    def spice_ports(self):
+        """
+        Dictionary mapping port names to corresponding port objects.
+        """
+        if not hasattr(self, '_spice_ports'):
+            self._spice_ports={}
+        return self._spice_ports
+
+    @spice_ports.setter
+    def spice_ports(self, val):
+        self._spice_ports=val
+
+
     def run_spice(self):
         """Externally called function to execute spice simulation.
 

--- a/spice/eldo/eldo_testbench.py
+++ b/spice/eldo/eldo_testbench.py
@@ -93,6 +93,22 @@ class eldo_testbench(testbench_common):
         self._libcmd=None
 
     @property
+    def portsrcstr(self):
+        """
+        Port source defintions parsed from from self.parent.spice_ports
+        """
+        if not hasattr(self, '_portsrcstr'):
+            self.portsrcstr=''
+            self.print_log(type='E', msg='Port support not yet implemented for Eldo!')
+        return self._portsrcstr
+    @portsrcstr.setter
+    def portsrcstr(self, val):
+        self._portsrcstr=val
+    @portsrcstr.deleter
+    def portsrcstr(self, val):
+        self._portsrcstr=None
+
+    @property
     def dcsourcestr(self):
         """String
         

--- a/spice/ngspice/ngspice_testbench.py
+++ b/spice/ngspice/ngspice_testbench.py
@@ -89,6 +89,23 @@ class ngspice_testbench(testbench_common):
     def libcmd(self,value):
         self._libcmd=None
 
+
+    @property
+    def portsrcstr(self):
+        """
+        Port source defintions parsed from from self.parent.spice_ports
+        """
+        if not hasattr(self, '_portsrcstr'):
+            self.portsrcstr=''
+            self.print_log(type='E', msg='Port support not yet implemented for ngspice!')
+        return self._portsrcstr
+    @portsrcstr.setter
+    def portsrcstr(self, val):
+        self._portsrcstr=val
+    @portsrcstr.deleter
+    def portsrcstr(self, val):
+        self._portsrcstr=None
+
     @property
     def dcsourcestr(self):
         """str : DC source definitions parsed from spice_dcsource objects instantiated

--- a/spice/spectre/spectre_testbench.py
+++ b/spice/spectre/spectre_testbench.py
@@ -119,7 +119,7 @@ class spectre_testbench(testbench_common):
         if not hasattr(self, '_portsrcstr'):
             self._portsrcstr = f"{self.parent.spice_simulator.commentchar} Port sources \n"
             for name,port in self.parent.spice_ports.items():
-                self.portsrcstr += f"{name} ({port.pos} {port.neg}) port num={port.num} res={port.res} type={port.type} freq={port.freq} mag={port.mag}\n"
+                self.portsrcstr += f"{name} ({port.pos} {port.neg}) port num={port.num} r={port.res} type={port.type} freq={port.freq} mag={port.mag}\n"
         return self._portsrcstr
     @portsrcstr.setter
     def portsrcstr(self, val):

--- a/spice/spectre/spectre_testbench.py
+++ b/spice/spectre/spectre_testbench.py
@@ -299,6 +299,22 @@ class spectre_testbench(testbench_common):
                             (sim,str(val.fmin),str(val.fmax),pts_str)
                     self._simcmdstr += '\n\n'
 
+                elif str(sim).lower() == 'sp':
+                    if val.fscale.lower()=='log':
+                        if val.fpoints != 0:
+                            pts_str='log=%d' % val.fpoints
+                        elif val.fstepsize != 0:
+                            pts_str='dec=%d' % val.fstepsize
+                        else:
+                            self.print_log(type='F', msg='Set either fpoints or fstepsize for SP simulation!')
+                    elif val.fscale.lower()=='lin':
+                        if val.fpoints != 0:
+                            pts_str='lin=%d' % val.fpoints
+                        elif val.fstepsize != 0:
+                            pts_str='step=%d' % val.fstepsize
+                        else:
+                            self.print_log(type='F', msg='Set either fpoints or fstepsize for SP simulation!')
+                    self._simcmdstr += f'SP_analysis sp ports=[{" ".join(self.parent.spice_ports.keys())}] start={val.fmin} stop={val.fmax} {pts_str} file=\"{self.parent.name}.s2p\" datafmt=touchstone datatype=realimag paramtype=s\n'
                 else:
                     self.print_log(type='E',msg='Simulation type \'%s\' not yet implemented.' % str(sim))
                 if val.mc:

--- a/spice/spectre/spectre_testbench.py
+++ b/spice/spectre/spectre_testbench.py
@@ -119,7 +119,9 @@ class spectre_testbench(testbench_common):
         if not hasattr(self, '_portsrcstr'):
             self._portsrcstr = f"{self.parent.spice_simulator.commentchar} Port sources \n"
             for name,port in self.parent.spice_ports.items():
-                self.portsrcstr += f"{name} ({port.pos} {port.neg}) port num={port.num} r={port.res} type={port.type} freq={port.freq} mag={port.mag}\n"
+                self.portsrcstr += f"{name} ({port.pos} {port.neg}) port num={port.num}\
+                        r={port.res} type={port.type} freq={port.freq} mag={port.mag}\
+                        dc={port.dc}\n"
         return self._portsrcstr
     @portsrcstr.setter
     def portsrcstr(self, val):

--- a/spice/spectre/spectre_testbench.py
+++ b/spice/spectre/spectre_testbench.py
@@ -110,6 +110,25 @@ class spectre_testbench(testbench_common):
     def libcmd(self,value):
         self._libcmd=None
 
+    
+    @property
+    def portsrcstr(self):
+        """
+        Port source defintions parsed from from self.parent.spice_ports
+        """
+        if not hasattr(self, '_portsrcstr'):
+            self._portsrcstr = f"{self.parent.spice_simulator.commentchar} Port sources \n"
+            for name,port in self.parent.spice_ports.items():
+                self.portsrcstr += f"{name} ({port.pos} {port.neg}) port num={port.num} res={port.res} type={port.type} freq={port.freq} mag={port.mag}\n"
+        return self._portsrcstr
+    @portsrcstr.setter
+    def portsrcstr(self, val):
+        self._portsrcstr=val
+    @portsrcstr.deleter
+    def portsrcstr(self, val):
+        self._portsrcstr=None
+
+
     @property
     def dcsourcestr(self):
         """str : DC source definitions parsed from spice_dcsource objects instantiated

--- a/spice/spice_iofile.py
+++ b/spice/spice_iofile.py
@@ -171,7 +171,7 @@ class spice_iofile(iofile):
         for ioname in self.ionames:
             if self.dir == 'out':
                 if self.psfasciiflag:
-                    #ANALYSIS NAME HARDCODED, MUST CURRENTLY BE 'PSS'! 
+                    #ANALYSIS NAME HARDCODED, MUST CURRENTLY BE 'PSS_analysis'! 
                     filename = 'tb_%s.raw/*PSS_analysis.fd.pss' % (self.parent.name) #return filename with wildcard for possible sweep (-> several files)
                 else:
                     filename = 'tb_%s.print' % (self.parent.name)
@@ -451,7 +451,7 @@ class spice_iofile(iofile):
                 if len(files)>1: #if True, a sweep was run
                     #extract folderpath 
                     foldername = os.path.dirname(files[0])
-                    files.remove(os.path.join(foldername,'PSS_analysis.fd.pss')) #this file not needed if sweeping (ANALYSIS NAME HARDCODED, MUST CURRENTLY BE 'PSS'!) 
+                    files.remove(os.path.join(foldername,'PSS_analysis.fd.pss')) #this file not needed if sweeping (ANALYSIS NAME HARDCODED, MUST CURRENTLY BE 'PSS_analysis'!) 
                     files = sorted(files) #glob doesn't return files in aplhabetical order
 
                 os.system('sync %s' % self.parent.spicesimpath) #Why this?

--- a/spice/spice_iofile.py
+++ b/spice/spice_iofile.py
@@ -460,11 +460,10 @@ class spice_iofile(iofile):
                 sweep=psf.get_sweep()
                 for signal in psf.all_signals():
                         tmpdata = np.vstack((sweep.abscissa, psf.get_signal(f'{signal.name}').ordinate)).T
-                        if signal.name.upper() in self.parent.iofile_eventdict: #first sweep index added as before (in else below)
-                            self.parent.iofile_eventdict[signal.name.upper()]=np.insert( self.parent.iofile_eventdict[signal.name.upper()], len(self.parent.iofile_eventdict[signal.name.upper()][0,:]-1), tmpdata[:,1], axis=1) #Add sweep iteration's result as column to io
+                        if signal.name.upper() in self.parent.iofile_eventdict: #first sweep index is added in else below
+                            self.parent.iofile_eventdict[signal.name.upper()]=np.insert( self.parent.iofile_eventdict[signal.name.upper()], len(self.parent.iofile_eventdict[signal.name.upper()][0,:]-1), tmpdata[:,1], axis=1) #Add sweep iteration's result as new column to io
                         else:
                             self.parent.iofile_eventdict[signal.name.upper()]=tmpdata
-                        #pdb.set_trace()
                 
         else:
             if len(self.file) == 0:

--- a/spice/spice_iofile.py
+++ b/spice/spice_iofile.py
@@ -23,7 +23,7 @@ import pandas as pd
 from numpy import genfromtxt
 import traceback
 from bitstring import BitArray
-from psf_utils import *
+import psf_utils.psf_utils as psfu
 
 class spice_iofile(iofile):
     """
@@ -447,7 +447,7 @@ class spice_iofile(iofile):
             else:
                 file=self.file[0] # File is the same for all psfascii type outputs
                 os.system('sync %s' % self.parent.spicesimpath) #Why this?
-            psf = PSF(file)
+            psf = psfu.PSF(file)
             sweep=psf.get_sweep()
             for signal in psf.all_signals():
                     print(f'{signal.name}') #test

--- a/spice/spice_iofile.py
+++ b/spice/spice_iofile.py
@@ -451,7 +451,7 @@ class spice_iofile(iofile):
             sweep=psf.get_sweep()
             for signal in psf.all_signals():
                     print(f'{signal.name}') #test
-                    tmpdata = np.vstack((sweep.abscissa, psf.get_signal(f'{signal.name}').ordinate))
+                    tmpdata = np.vstack((sweep.abscissa, psf.get_signal(f'{signal.name}').ordinate)).T
                     self.parent.iofile_eventdict[signal.name.upper()]=tmpdata
                 
         else:

--- a/spice/spice_iofile.py
+++ b/spice/spice_iofile.py
@@ -449,9 +449,9 @@ class spice_iofile(iofile):
                 import glob
                 files = glob.glob(self.file[0]) #filepath with wildcard -> list of filepath strings 
                 if len(files)>1: #if True, a sweep was run
-                    #extract folderpath 
-                    foldername = os.path.dirname(files[0])
-                    files.remove(os.path.join(foldername,'PSS_analysis.fd.pss')) #this file not needed if sweeping (ANALYSIS NAME HARDCODED, MUST CURRENTLY BE 'PSS_analysis'!) 
+                    ##extract folderpath 
+                    #foldername = os.path.dirname(files[0])
+                    #files.remove(os.path.join(foldername,'PSS_analysis.fd.pss')) #this file not needed if sweeping (ANALYSIS NAME HARDCODED, MUST CURRENTLY BE 'PSS_analysis'!) 
                     files = sorted(files) #glob doesn't return files in aplhabetical order
 
                 os.system('sync %s' % self.parent.spicesimpath) #Why this?

--- a/spice/spice_port.py
+++ b/spice/spice_port.py
@@ -1,0 +1,47 @@
+import traceback
+
+class spice_port():
+    '''
+    Class for providing port objects for spice simulations. When created,
+    adds it self to the parents spice_ports dictionary and is accessible as
+    parent.spice_ports['name'].
+
+    Attributes
+    ----------
+    parent : object
+        The parent object initializing the spice_port instance. Default None
+    name: str
+        Name of the port. Must be unique within top-level netlist. Default: "PORT<self.num>"
+    pos: str
+        Node to which the positive terminal of the port is to be attached
+    neg: str
+        Node to which the negative terminal of the port is to be attached
+    res: float or int
+        Series resistance of the port
+    num: int
+        Number of the port (for S-parameter analysis)
+    type: str
+        TODO: IS THIS NEEDED?
+        Type of source, e.g. 'sine', 'dc'.
+    freq: str
+        TODO: IS THIS NEEDED?
+        Point frequency of source.
+    '''
+
+    def __init__(self, parent=None, **kwargs):
+        if parent == None:
+            self.print_log(type='F', msg="Parent of spice input file not given")
+        try:
+            self.pos=kwargs.get('pos', None)
+            self.neg=kwargs.get('neg', None)
+            self.res=kwargs.get('res', 50)
+            self.num=kwargs.get('num', 1)
+            self.type=kwargs.get('type', 'sine')
+            self.freq=kwargs.get('dc', 0)
+            self.name=kwargs.get('name', f'PORT{self.num}')
+            self.parent.spice_ports[self.name] = self
+        except:
+            self.print_log(type='W', msg="Something went wrong with defining a spice port.")
+            self.print_log(type='W', msg=traceback.format_exc())
+            self.print_log(type='F', msg="Exiting.")
+

--- a/spice/spice_port.py
+++ b/spice/spice_port.py
@@ -45,6 +45,7 @@ class spice_port(thesdk):
             self.num=kwargs.get('num', 1)
             self.type=kwargs.get('type', 'sine')
             self.freq=kwargs.get('freq', 1e6)
+            self.dc=kwargs.get('dc', 0)
             self.mag=kwargs.get('mag', 1)
             self.name=kwargs.get('name', f'PORT{self.num}')
             self.parent.spice_ports[self.name] = self

--- a/spice/spice_port.py
+++ b/spice/spice_port.py
@@ -1,6 +1,7 @@
+from thesdk import *
 import traceback
 
-class spice_port():
+class spice_port(thesdk):
     '''
     Class for providing port objects for spice simulations. When created,
     adds it self to the parents spice_ports dictionary and is accessible as
@@ -19,10 +20,15 @@ class spice_port():
     res: float or int
         Series resistance of the port
     num: int
-        Number of the port (for S-parameter analysis)
+        Number of the port (for S-parameter analysis). Must be larger than zero.
+        Default: 1.
     type: str
         TODO: IS THIS NEEDED?
         Type of source, e.g. 'sine', 'dc'.
+    mag: float
+        Magnitude of the small signal waveform. Used for small-signal type analyses, such
+        as AC, SP, etc.
+        Default: 1.0 
     freq: str
         TODO: IS THIS NEEDED?
         Point frequency of source.
@@ -32,14 +38,18 @@ class spice_port():
         if parent == None:
             self.print_log(type='F', msg="Parent of spice input file not given")
         try:
+            self.parent=parent
             self.pos=kwargs.get('pos', None)
             self.neg=kwargs.get('neg', None)
             self.res=kwargs.get('res', 50)
             self.num=kwargs.get('num', 1)
             self.type=kwargs.get('type', 'sine')
-            self.freq=kwargs.get('dc', 0)
+            self.freq=kwargs.get('freq', 1e6)
+            self.mag=kwargs.get('mag', 1)
             self.name=kwargs.get('name', f'PORT{self.num}')
             self.parent.spice_ports[self.name] = self
+            if self.num < 1:
+                self.print_log(type='F', msg="Port number must be greater than zero!")
         except:
             self.print_log(type='W', msg="Something went wrong with defining a spice port.")
             self.print_log(type='W', msg=traceback.format_exc())

--- a/spice/testbench.py
+++ b/spice/testbench.py
@@ -240,6 +240,21 @@ class testbench(testbench_common):
     def dcsourcestr(self,value):
         self.testbench_simulator.dcsourcestr = value
 
+
+    @property
+    def portsrcstr(self):
+        """
+        Documentation for parameter portsrcstr
+        """
+        if not hasattr(self, '_portsrcstr'):
+            self._portsrcstr=self.testbench_simulator.portsrcstr
+        return self._portsrcstr
+
+    @portsrcstr.setter
+    def portsrcstr(self, val):
+        self._portsrcstr=val
+
+
     @property
     def inputsignals(self):
         """str : Input signal definitions parsed from spice_iofile objects instantiated
@@ -309,6 +324,7 @@ class testbench(testbench_common):
                         self.dut.instance + "\n\n" +
                         self.misccmd + "\n" +
                         self.dcsourcestr + "\n" +
+                        self.portsrcstr + "\n" +
                         self.inputsignals + "\n" +
                         self.simcmdstr + "\n" +
                         self.plotcmd + "\n" +


### PR DESCRIPTION
Goal is to add support for enabling steady state and S-parameter analyses, at least in Spectre.

- Frequency domain outputs should be put into iofile which has iotype='freq'
- Iotype 'freq' should be a column matrix, where the first column is frequency and the rest of the columns are (complex) magnitude
- S-parameters to self.extracts.Members['sparams']
- Simulator internal sweeping for pss?

@kspoof 