### PR TITLE
Add sed script to add missing space separator

### DIFF
--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -540,12 +540,12 @@ class spice(spice_common):
                 else:
                     if self.interactive_spice:
                         if not self.distributed_run:
-                            self._spice_submission = thesdk.GLOBALS['LSFINTERACTIVE'] + ' '
+                            self._spice_submission = thesdk.GLOBALS['LSFINTERACTIVE'] + ' -n %s ' % self.nproc
                         else: # Spectre LSF doesn't support interactive queues
                             self.print_log(type='W', msg='Cannot run in interactive mode if distributed mode is on!')
-                            self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt ' % (self.spicesimpath)
+                            self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt -n %s ' % (self.spicesimpath, self.nproc)
                     else:
-                        self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt ' % (self.spicesimpath)
+                        self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt -n %s ' % (self.spicesimpath, self.nproc)
 
             except:
                 self.print_log(type='W',msg='Error while defining spice submission command. Running locally.')


### PR DESCRIPTION
This PR implements a fix on the case where output file does not round to zero, which can happen with verilogA components, which leads to the different value columns merging to eachother, if the exponent is increased over 100. The proposed fix adds the missing spacebar, which fixes the issue.

Please test, approve and merge @sporrasm @alttiheikkinen 