### PR TITLE
Fix crashing if nproc is not defined

### DIFF
--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -540,12 +540,14 @@ class spice(spice_common):
                 else:
                     if self.interactive_spice:
                         if not self.distributed_run:
-                            self._spice_submission = thesdk.GLOBALS['LSFINTERACTIVE'] + ' -n %s ' % self.nproc
+                            self._spice_submission = thesdk.GLOBALS['LSFINTERACTIVE']
                         else: # Spectre LSF doesn't support interactive queues
                             self.print_log(type='W', msg='Cannot run in interactive mode if distributed mode is on!')
-                            self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt -n %s ' % (self.spicesimpath, self.nproc)
+                            self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt ' % (self.spicesimpath)
                     else:
-                        self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt -n %s ' % (self.spicesimpath, self.nproc)
+                        self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt ' % (self.spicesimpath)
+                    if self.nproc:
+                        self._spice_submission+=' -n %s ' % self.nproc
 
             except:
                 self.print_log(type='W',msg='Error while defining spice submission command. Running locally.')


### PR DESCRIPTION
This commit fixes the issues that spice crashes if nproc is not defined. The nproc flag is added to the simulation command only if npoc is defined.