### PR TITLE
changes to imports for better readability and better exception handling

### DIFF
--- a/spice/spice_methods.py
+++ b/spice/spice_methods.py
@@ -8,11 +8,11 @@ Initially restructured to this package Marko Kosunen 2022
 
 
 import os
-import sys
-from abc import * 
-from thesdk import *
+import numpy as np
+from abc import ABCMeta 
+from thesdk import traceback 
 
-class spice_methods(metaclass=abc.ABCMeta):
+class spice_methods(metaclass=ABCMeta):
 
     def filter_strobed(self, key,ioname):
         """
@@ -81,7 +81,7 @@ class spice_methods(metaclass=abc.ABCMeta):
             tdiff = np.diff(self.iofile_eventdict[key.upper()][:,0])
             if np.any(tdiff == 0.0):
                     self.print_log(type='W', msg='Accuracy of output file is insufficient. Increase value of \'digits\' parameter and re-run simulation!')
-        except: # Requested output wasn't in output file, do nothing
+        except Exception: # Requested output wasn't in output file, do nothing
             self.print_log(type='W',msg='Couldn\'t check output file accuracy')
             self.print_log(type='W',msg=traceback.format_exc())
 


### PR DESCRIPTION
Cleaned up imports by using explicit imports for better readability and modified bare `except:` as specified by PEP8, because leaving it like this catches exceptions, such as `KeyboardInterrupt` which is usually undesired