### PR TITLE
Dont add the brackets if the sample IO is for one IO instead of a bus

### DIFF
--- a/spice/spice_iofile.py
+++ b/spice/spice_iofile.py
@@ -325,11 +325,9 @@ class spice_iofile(iofile):
                         # This is Spectre vector file syntax
                         outfile.write("radix %s\n" % ("1 " * buswidth))
                         outfile.write("io i\n")
+                        ioname = self.ionames[i] if ':' not in self.ionames[i] else self.ionames[i].replace("<","<[").replace(">", "]>")
                         outfile.write(
-                            "vname %s\n"
-                            % self.ionames[i]
-                            .replace("<", "<[")
-                            .replace(">", "]>")
+                            f"vname {ioname}\n"
                         )
                         outfile.write("tunit ns\n")
                         outfile.write(f"period {1e9/float(self.rs)}\n")


### PR DESCRIPTION
Hi,
found a nice feature in spice as I happened to do something that I don't think has been done before.

The sample iotype did not work if the bus width was one (just e.g. <0> instead of <10:0>). This PR should fix it.

Please test if this breaks any case you have using sample IO types. @MiikkaMaki @sporrasm 