### PR TITLE
Fix broken interactive

### DIFF
--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -544,7 +544,7 @@ class spice(spice_common):
                 else:
                     if self.interactive_spice:
                         if not self.distributed_run:
-                            self._spice_submission = thesdk.GLOBALS['LSFINTERACTIVE']
+                            self._spice_submission = thesdk.GLOBALS['LSFINTERACTIVE'] + ' '
                         else: # Spectre LSF doesn't support interactive queues
                             self.print_log(type='W', msg='Cannot run in interactive mode if distributed mode is on!')
                             self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt ' % (self.spicesimpath)
@@ -552,7 +552,6 @@ class spice(spice_common):
                         self._spice_submission = thesdk.GLOBALS['LSFSUBMISSION'] + ' -o %s/bsublog.txt ' % (self.spicesimpath)
                     if self.nproc:
                         self._spice_submission+=' -n %s ' % self.nproc
-
             except:
                 self.print_log(type='W',msg='Error while defining spice submission command. Running locally.')
                 self._spice_submission=''


### PR DESCRIPTION
Interactive may not work due to missing spaces. TheSyDeKick test bench may have options that add spaces after the LSFINTERACTIVE, in which case interactive works. If it doesn't have any options, this may lead to flawed submission command. Extra spaces never hurt.